### PR TITLE
docs: add monitor reset halt tip to Debug It chapter

### DIFF
--- a/mdbook/src/05-meet-your-software/debug-it.md
+++ b/mdbook/src/05-meet-your-software/debug-it.md
@@ -196,6 +196,15 @@ of the instruction the processor will execute next.
 
 One last trick before we move to something more interesting. Enter the following commands into GDB:
 
+**Bonus tip:** If your execution accidentally runs past your `break main`, you can reset and halt the MCU to ensure the breakpoint is properly hit:
+
+```shell
+(gdb) monitor reset halt
+(gdb) continue
+```
+
+This command resets the microcontroller and halts it at the entry point, guaranteeing that the next `continue` command stops at the intended `main` breakpoint.
+
 ```
 (gdb) monitor reset
 (gdb) c


### PR DESCRIPTION
## Summary
- document `monitor reset halt` tip in the Debug It chapter. Cargo Embed runs the program and it's past main when you make the break point and hit continue. Reset Halt makes it start from scratch and the code in the book will work
-